### PR TITLE
Made fs.watchfile non-persistent so gulp can finish fix #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function Config(pathToConfigFileIn, region) {
     debug('pathToDeafults: '+this.pathToDefaults);
 
     // set a watch for when the file changes, to reload the file.
-    fs.watchFile(this.pathToConfigFile, function () {
+    fs.watchFile(this.pathToConfigFile, {persistent: false}, function () {
         self.loadConfig(self.pathToDefaults, self.pathToConfigFile, self.region);
     });
 


### PR DESCRIPTION
Gulp is not finishing, because the watchFile method of fs requires the persistent:false config option

**Tests**
```> config-js@1.1.9 test /config-js
> mocha --reporter list ./test/test.js


  ․ Config() Should throw if pathToConfigFile is an empty string: 1ms
  ․ Config() Should throw if pathToConfigFile is not a string: 1ms
  ․ Config() Should throw if pathToConfigFile does not point to a file: 0ms
  ․ get() Should retrieve values from the configuration file and default val: 1ms
  ․ get() Should retrieve values from the environment: 0ms
  ․ get() Should throw when no value is available: 0ms
  ․ get() Should retrieve values from  with different sep chars: 0ms
  ․ getByRegion() Should retrieve values from the configured region of the config file: 2ms
  ․ Config() Should subst '##' wth contents of NODE_ENV env var : 1ms

  9 passing (13ms)```